### PR TITLE
added support for more git labels on release note generation

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -11,11 +11,14 @@ export:
   regex-text: '### Where to get it(\r\n)*You can .*\)'
   multiline-regex: true
 issue-labels-include:
-- Breaking change
-- Feature
-- Bug
-- Improvement
-- Documentation
+- breaking change
+- feature
+- bug
+- improvement
+- documentation
+- xamarin-ios
+- xamarin-forms
+- xamarin-android
 issue-labels-exclude:
 - Build
 issue-labels-alias:

--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -22,6 +22,9 @@ issue-labels-include:
 issue-labels-exclude:
 - Build
 issue-labels-alias:
-    - name:    Documentation
+    - name:    documentation
       header:  Documentation
       plural:  Documentation
+    - name:    xamarin-forms
+      header:  Xamarin Forms
+      plural:  Xamarin Forms


### PR DESCRIPTION
## Description of Change ##

added support for more git labels on release note generation in GitReleaseManager.yaml

## Issues Resolved ##

(if this PR resolves an issue, please specify the issue number after the hash below)

* fixes #17 

## API Changes ##
None
## PR Checklist ##

- [ ] have run `./build.sh` from the `build` folder and fix any errors or failed unit tests
- [ ] code follows the style guidelines described in [Coding Style](https://github.com/BlueChilli/ChilliSource/blob/master/doc/coding-style-dotnet.md)
- [ ] changes don't break API compatibility
- [ ] code has tests if applicable
- [ ] code that is not your own has attribution
- [ ] code is adequately commented